### PR TITLE
New Raspberry Pi OS has vcgencmd in /usr/bin

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@ var spawn = require("child_process").spawn;
 
 module.exports.measure = function(callback) {
 	var regex = /temp=([^'C]+)/;
-	var cmd = spawn("/opt/vc/bin/vcgencmd", ["measure_temp"]);
+	var cmd = spawn("/usr/bin/vcgencmd", ["measure_temp"]);
 
 	cmd.stdout.on("data", function(buf) {
 		callback(null, parseFloat(regex.exec(buf.toString("utf8"))[1]));


### PR DESCRIPTION
The latest versions of Raspberry Pi OS distribute vcgencmd to `/usr/bin/vcgencmd`. Can we update the path here?